### PR TITLE
Upgrade project to .NET 8 and add support for SQL Server testing via Docker container

### DIFF
--- a/DbAccessCodeGen.Library/DbAccessCodeGen.Library.csproj
+++ b/DbAccessCodeGen.Library/DbAccessCodeGen.Library.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>Enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <RootNamespace>DbAccessCodeGen</RootNamespace>

--- a/DbAccessCodeGen.Library/DbAccessCodeGen.Library.csproj
+++ b/DbAccessCodeGen.Library/DbAccessCodeGen.Library.csproj
@@ -1,43 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6</TargetFramework>
     <Nullable>Enable</Nullable>
     <LangVersion>10.0</LangVersion>
     <RootNamespace>DbAccessCodeGen</RootNamespace>
-    
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Templates\DbCodeGenConfig.scriban-cs" />
     <None Remove="Templates\ModelFile.scriban-cs" />
     <None Remove="Templates\ServiceClass.scriban-cs" />
     <None Remove="Templates\ServiceMethod.scriban-cs" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Templates\DbCodeGenConfig.scriban-cs" />
     <EmbeddedResource Include="Templates\ModelFile.scriban-cs">
     </EmbeddedResource>
     <EmbeddedResource Include="Templates\ServiceClass.scriban-cs">
-
     </EmbeddedResource>
     <EmbeddedResource Include="Templates\ServiceMethod.scriban-cs">
-
     </EmbeddedResource>
   </ItemGroup>
-<ItemGroup>
-    <PackageReference Include="Kull.Data" Version="6.0.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.2" />
-  <PackageReference Include="Jint" Version="3.0.0-beta-2037" />
-    <PackageReference Include="Kull.DatabaseMetadata" Version="1.5.0-beta7" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-3.final" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2-mauipre.1.22102.15" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.2-mauipre.1.22102.15" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.2-mauipre.1.22102.15" />
-    <PackageReference Include="Scriban" Version="5.4.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
-</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Kull.Data" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <PackageReference Include="Jint" />
+    <PackageReference Include="Kull.DatabaseMetadata" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Scriban" />
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
 </Project>

--- a/DbAccessCodeGen.Test/DbAccessCodeGen.Test.csproj
+++ b/DbAccessCodeGen.Test/DbAccessCodeGen.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/DbAccessCodeGen.Test/DbAccessCodeGen.Test.csproj
+++ b/DbAccessCodeGen.Test/DbAccessCodeGen.Test.csproj
@@ -1,20 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.9-preview-20220210-07" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.9-preview-20220210-07" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="CliWrap" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
 </Project>

--- a/DbAccessCodeGen.Test/IntegrationTest.cs
+++ b/DbAccessCodeGen.Test/IntegrationTest.cs
@@ -68,7 +68,7 @@ namespace DbAccessCodeGen.Test
         {
             var solutionDir = GetSolutionDir();
 
-            await ExecuteAndAssertSuccess(Path.Combine(solutionDir, "DbCode.Test"), 60, Path.Combine(solutionDir, "DbAccessCodeGen/bin/Debug/net6/DbAccessCodeGen.exe"),
+            await ExecuteAndAssertSuccess(Path.Combine(solutionDir, "DbCode.Test"), 60, Path.Combine(solutionDir, "DbAccessCodeGen/bin/Debug/net8.0/DbAccessCodeGen.exe"),
                 "-c", "DbCodeGenConfig.yml");
         }
 
@@ -85,7 +85,7 @@ namespace DbAccessCodeGen.Test
         {
             var solutionDir = GetSolutionDir();
 
-            await ExecuteAndAssertSuccess(Path.Combine(solutionDir, "DbCode.Test"), 60, "dotnet", "run", "--framework", "netcoreapp3.1");
+            await ExecuteAndAssertSuccess(Path.Combine(solutionDir, "DbCode.Test"), 60, "dotnet", "run", "--framework", "net8.0");
         }
 
 
@@ -110,8 +110,16 @@ namespace DbAccessCodeGen.Test
                 }))
                 .WithStandardErrorPipe(PipeTarget.ToDelegate(h =>
                 {
+                    if (
+                    //remove logs from the container
+                        (h.Contains("Network dbcodetest_default") == false) 
+                        && (h.Contains("Container dbcodetest-sql-server-test-1") == false)
+                        && (h.Contains("docker-compose.yml") == false)
+                    )
+                    {                     
+                        lines.Add(h);
+                    }
                     TestContext.WriteLine("ERROR: " + h);
-                    lines.Add(h);
                 }))
                 .WithValidation(CommandResultValidation.None); // We validate our-selves
             var cts = new CancellationTokenSource();

--- a/DbAccessCodeGen/DbAccessCodeGen.csproj
+++ b/DbAccessCodeGen/DbAccessCodeGen.csproj
@@ -1,39 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net6</TargetFramework>
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>dbcodegen</ToolCommandName>
-		<PackageOutputPath>./nupkg</PackageOutputPath>
-		<RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
-		<Nullable>Enable</Nullable>
-		<Version>0.7.1</Version>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<RepositoryURL>https://github.com/aersamkull/DbAccessCodeGen</RepositoryURL>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Jint" Version="3.0.0-beta-2037" />
-		<PackageReference Include="Kull.Data" Version="6.0.3" />
-		<PackageReference Include="Kull.DatabaseMetadata" Version="1.5.0-beta7" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-3.final" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.2-mauipre.1.22102.15" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.2-mauipre.1.22102.15" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.2-mauipre.1.22102.15" />
-		<PackageReference Include="Mono.Options" Version="6.12.0.148" />
-		<PackageReference Include="Scriban" Version="5.4.0" />
-		<PackageReference Include="YamlDotNet" Version="11.2.1" />
-
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\DbAccessCodeGen.Library\DbAccessCodeGen.Library.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="Init\" />
-	</ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>dbcodegen</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    <Nullable>Enable</Nullable>
+    <Version>0.7.1</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryURL>https://github.com/aersamkull/DbAccessCodeGen</RepositoryURL>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Jint" />
+    <PackageReference Include="Kull.Data" />
+    <PackageReference Include="Kull.DatabaseMetadata" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Mono.Options" />
+    <PackageReference Include="Scriban" />
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbAccessCodeGen.Library\DbAccessCodeGen.Library.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Init\" />
+  </ItemGroup>
 </Project>

--- a/DbCode.Test/DbCode.Test.csproj
+++ b/DbCode.Test/DbCode.Test.csproj
@@ -1,24 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;netstandard2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
-
   <ItemGroup>
     <Content Include=".config\dotnet-tools.json" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.2-mauipre.1.22102.15" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="DbCodeGenConfig.yml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -27,9 +22,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Utils\" />
   </ItemGroup>
-
 </Project>

--- a/DbCode.Test/DbCode.Test.csproj
+++ b/DbCode.Test/DbCode.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
   </PropertyGroup>

--- a/DbCode.Test/DbCodeGenConfig.yml
+++ b/DbCode.Test/DbCodeGenConfig.yml
@@ -5,7 +5,7 @@ NamingJS: "naming.js"
 GenerateAsyncCode: true
 GenerateAsyncStreamCode: false
 GenerateSyncCode: true
-ConnectionString: "Server=(LocalDB)\\MSSQLLocalDB; Integrated Security=true;Initial Catalog=CodeGenTestDb;MultipleActiveResultSets=true"
+ConnectionString: "Server=127.0.0.1;user id=sa;password=abcDEF123#;Initial Catalog=CodeGenTestDb;MultipleActiveResultSets=true;TrustServerCertificate=True;"
 ReplaceParameters:
    DateOfTool: DateTime.Now
 Items:

--- a/DbCode.Test/Dockerfile.db
+++ b/DbCode.Test/Dockerfile.db
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/mssql/server:2019-latest as sqlserver
+
+USER root
+
+ENV ACCEPT_EULA=Y 
+ENV SA_PASSWORD=abcDEF123#
+ENV MSSQL_PID=Developer
+ENV MSSQL_TCP_PORT=1433 
+
+
+RUN ((/opt/mssql/bin/sqlservr --accept-eula & ) | grep -q "Service Broker manager has started")

--- a/DbCode.Test/Program.cs
+++ b/DbCode.Test/Program.cs
@@ -13,7 +13,7 @@ namespace DbCode.Test
             if (!DbProviderFactories.TryGetFactory("Microsoft.Data.SqlClient", out var _))
                 DbProviderFactories.RegisterFactory("Microsoft.Data.SqlClient", Microsoft.Data.SqlClient.SqlClientFactory.Instance);
 #endif
-            string conStr = "Server=(LocalDB)\\MSSQLLocalDB; Integrated Security=true;Initial Catalog=CodeGenTestDb;MultipleActiveResultSets=true";
+            string conStr = "Server=127.0.0.1;user id=sa;password=abcDEF123#;Initial Catalog=CodeGenTestDb;MultipleActiveResultSets=true;TrustServerCertificate=True;";
 
             var props = typeof(spGetPetsResult).GetProperties(System.Reflection.BindingFlags.GetProperty | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                 .Select(s => s.Name).ToArray();

--- a/DbCode.Test/ResultSets/dbo.spGetPet.json
+++ b/DbCode.Test/ResultSets/dbo.spGetPet.json
@@ -27,6 +27,6 @@
     "Name": "ts",
     "TypeName": "timestamp",
     "IsNullable": false,
-    "MaxLength": null
+    "MaxLength": 8
   }
 ]

--- a/DbCode.Test/ResultSets/dbo.spGetPets.json
+++ b/DbCode.Test/ResultSets/dbo.spGetPets.json
@@ -21,7 +21,7 @@
     "Name": "ts",
     "TypeName": "timestamp",
     "IsNullable": false,
-    "MaxLength": null
+    "MaxLength": 8
   },
   {
     "Name": "IsARealPet%",

--- a/DbCode.Test/ResultSets/dbo.spSearchPets.json
+++ b/DbCode.Test/ResultSets/dbo.spSearchPets.json
@@ -27,6 +27,6 @@
     "Name": "ts",
     "TypeName": "timestamp",
     "IsNullable": false,
-    "MaxLength": null
+    "MaxLength": 8
   }
 ]

--- a/DbCode.Test/ResultSets/dbo.spTestBackend.json
+++ b/DbCode.Test/ResultSets/dbo.spTestBackend.json
@@ -9,6 +9,6 @@
     "Name": "Name",
     "TypeName": "nvarchar",
     "IsNullable": true,
-    "MaxLength": 4000
+    "MaxLength": 1000
   }
 ]

--- a/DbCode.Test/SetupDB.ps1
+++ b/DbCode.Test/SetupDB.ps1
@@ -1,7 +1,8 @@
-﻿docker-compose up -d
+﻿docker-compose up -d  > $null #remove status entries
 
+Start-Sleep -Seconds 20 
 
-$server = "localhost,1433"
+$server = "127.0.0.1"
 $user = "sa"
 $pw = "abcDEF123#"
 $db = "CodeGenTestDb"
@@ -33,9 +34,10 @@ else {
 }
 if($createNewDb) {
     Write-Host "recreate db"
-    & "sqlcmd" -S  $server -U $user -P $pw -d master -Q "DROP DATABASE $db"
+    & "sqlcmd" -S  $server -U $user -P $pw -d master -Q "DROP DATABASE IF EXISTS $db"
     & "sqlcmd" -S  $server -U $user -P $pw -d master -Q "CREATE DATABASE $db"
-    & "sqlcmd" -i "$PSScriptRoot\sqlscript.sql" -S $server -d $db -v DbVersion=1
+    & "sqlcmd" -i "$PSScriptRoot\sqlscript.sql" -S $server -U $user -P $pw -d $db -v DbVersion=1
 }
 
-docker-compose down -f
+#destroy the container
+#docker-compose down

--- a/DbCode.Test/SetupDB.ps1
+++ b/DbCode.Test/SetupDB.ps1
@@ -1,11 +1,19 @@
-﻿$server = "(LocalDB)\MSSQLLocalDB"
+﻿docker-compose up -d
+
+
+$server = "localhost,1433"
+$user = "sa"
+$pw = "abcDEF123#"
 $db = "CodeGenTestDb"
 $shouldVNr = 14
-$hasDb = ( & "sqlcmd" -E -S $server -d master -Q "SELECT name FROM sys.databases" ) | Where-Object { $_.Trim() -eq $db }
+$hasDb = ( & "sqlcmd" -S $server -d master -Q "SELECT name FROM sys.databases" -U $user -P $pw ) | Where-Object { $_.Trim() -eq $db }
+
+Write-Host "has database $hasDb"
+
 $createNewDb = $false
 if ($hasDb) {
     Write-Host "Db exists"
-    $outputVersion = & "sqlcmd" -S "(LocalDB)\MSSQLLocalDB" -d $db -Q "SELECT * FROM TestDbVersion"
+    $outputVersion = & "sqlcmd" -S $server -U $user -P $pw -d $db -Q "SELECT * FROM TestDbVersion"
     
     if($outputVersion -like '*invalid object name*')
     {
@@ -25,7 +33,9 @@ else {
 }
 if($createNewDb) {
     Write-Host "recreate db"
-    & "sqlcmd" -E -S  $server -d master -Q "DROP DATABASE $db"
-    & "sqlcmd" -E -S  $server -d master -Q "CREATE DATABASE $db"
+    & "sqlcmd" -S  $server -U $user -P $pw -d master -Q "DROP DATABASE $db"
+    & "sqlcmd" -S  $server -U $user -P $pw -d master -Q "CREATE DATABASE $db"
     & "sqlcmd" -i "$PSScriptRoot\sqlscript.sql" -S $server -d $db -v DbVersion=1
 }
+
+docker-compose down -f

--- a/DbCode.Test/docker-compose.yml
+++ b/DbCode.Test/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+services:
+  sql-server-test:
+    build:
+      context: .
+      dockerfile: Dockerfile.db
+    ports:
+      - "1433:1433"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,30 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    <NoWarn>$(NoWarn);NU1507</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="CliWrap" Version="3.4.1" />
+    <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="Jint" Version="3.0.0-beta-2037" />
+    <PackageVersion Include="Kull.Data" Version="8.0.1" />
+    <PackageVersion Include="Kull.DatabaseMetadata" Version="1.7.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.2-mauipre.1.22102.15" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-3.final" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
+    <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="2.2.9-preview-20220210-07" />
+    <PackageVersion Include="MSTest.TestFramework" Version="2.2.9-preview-20220210-07" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Scriban" Version="5.4.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="YamlDotNet" Version="11.2.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This pull request upgrades the entire project to .NET 8. Additionally, it introduces the option to run integration tests using a SQL Server instance hosted in a Docker container, simplifying the local development and testing workflow.

![image](https://github.com/user-attachments/assets/c4295898-ed25-4f9a-b419-d3df285d0486)
