### PR TITLE
Upgrade to .NET 8 and add support for custom SP naming with escaping

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,17 +8,15 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '6.0.x'
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: cd DbAccessCodeGen && dotnet build --configuration Release --no-restore
-
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "8.0.x"
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: cd DbAccessCodeGen && dotnet build --configuration Release --no-restore

--- a/DbAccessCodeGen.Library/Configuration/DBOperationSetting.cs
+++ b/DbAccessCodeGen.Library/Configuration/DBOperationSetting.cs
@@ -14,19 +14,47 @@ namespace DbAccessCodeGen.Configuration
         Dictionary=4
     }
 
+    public partial class SpecificDBNaming
+    {
+        public string DBSchemaName { get; private set; }
+        public string DBObjectName { get; private set; }
+        public static SpecificDBNaming? CreateSpecifcDBNaming(string? dbSchemaName, string? dbObjectName)
+        {
+            if (!string.IsNullOrEmpty(dbObjectName) && !string.IsNullOrEmpty(dbSchemaName))
+            {
+                return new SpecificDBNaming()
+                {
+                    DBSchemaName = dbSchemaName,
+                    DBObjectName = dbObjectName,
+                };
+            }
+            return null;
+        }
+    }
+
     public partial class DBOperationSetting
     {
-        public DBOperationSetting(string dbObjectName,
+        public DBOperationSetting(string? dbObjectName,
             DBObjectType objectType,
             string? methodName,
-            IReadOnlyDictionary<string, object?>? executeParameters, IReadOnlyCollection<string>? ignoreParameters)
+            IReadOnlyDictionary<string, object?>? executeParameters, IReadOnlyCollection<string>? ignoreParameters,
+            SpecificDBNaming? specificDBNaming)
         {
             this.DBObjectType = objectType;
-            DBObjectName = dbObjectName ?? throw new ArgumentNullException(nameof(dbObjectName));
-            if (DBObjectName.Schema == null)
-            {
-                DBObjectName = new DBObjectName("dbo" /* we assume default schema dbo */, DBObjectName.Name);
+
+            //Check if specific db object naming is set
+            if (specificDBNaming != null) {
+                DBObjectName = new DBObjectName(specificDBNaming.DBSchemaName, specificDBNaming.DBObjectName);
             }
+            else
+            {
+                DBObjectName = dbObjectName ?? throw new ArgumentNullException(nameof(dbObjectName));
+                if (DBObjectName.Schema == null)
+                {
+                    DBObjectName = new DBObjectName("dbo" /* we assume default schema dbo */, DBObjectName.Name);
+                }
+            }
+
             ExecuteParameters = executeParameters;
             IgnoreParameters = ignoreParameters;
             MethodName = methodName;
@@ -51,6 +79,12 @@ namespace DbAccessCodeGen.Configuration
 
         public DBOperationResultType ResultType { get; init; } = DBOperationResultType.Result;
 
+        /// <summary>
+        /// Option to set the specific naming of the object
+        /// Warning: Could be null
+        /// </summary>
+        public SpecificDBNaming? SpecificDBNaming { get; init; }
+
 
         public static DBOperationSetting FromObject(object obj)
         {
@@ -71,26 +105,29 @@ namespace DbAccessCodeGen.Configuration
                     ignoreParameters = o.Select(o => (string)Convert.ChangeType(o, typeof(string))).ToArray();
                 }
                 var replaceParameters = os.GetOrThrow<IReadOnlyDictionary<string, string>?>(nameof(ReplaceParameters), null);
-                string dbObjectName;
+                string? dbObjectName;
                 DBObjectType type;
                 if (os.ContainsKey("SP"))
                 {
-                    dbObjectName = (string)os["SP"];
+                    dbObjectName = (string?)os["SP"];
                     type = DBObjectType.StoredProcedure;
                 }
                 else if (os.ContainsKey("View"))
                 {
-                    dbObjectName = (string)os["View"];
+                    dbObjectName = (string?)os["View"];
                     type = DBObjectType.TableOrView;
                 }
                 else
                 {
                     throw new InvalidOperationException("Must set either SP or View, but never both");
                 }
-                return new DBOperationSetting(dbObjectName, 
+
+                return new DBOperationSetting(dbObjectName,
                     type,
                     methodName: os.GetOrThrow("MethodName", (string?)null),
-                    executeParameters: (IReadOnlyDictionary<string, object?>?)executeParameters, ignoreParameters: (IReadOnlyCollection<string>?)ignoreParameters)
+                    executeParameters: (IReadOnlyDictionary<string, object?>?)executeParameters, ignoreParameters: (IReadOnlyCollection<string>?)ignoreParameters,
+                    specificDBNaming: GetSpecificDBObjectNaming(os)
+                    )
                 {
                     GenerateSyncCode = os.GetOrThrow<bool?>(nameof(GenerateSyncCode), null),
                     GenerateAsyncCode = os.GetOrThrow<bool?>(nameof(GenerateAsyncCode), null),
@@ -99,12 +136,34 @@ namespace DbAccessCodeGen.Configuration
                     CustomTypeMappings = os.GetOrThrow<IReadOnlyDictionary<string, string>?>(nameof(CustomTypeMappings), null),
                     IgnoreFields = os.GetOrThrow<IReadOnlyCollection<string>?>(nameof(IgnoreFields), null),
                     ResultType = os.GetOrThrow<bool>("ExecuteOnly", false) ? DBOperationResultType.AffectedRows
-                        : os.GetOrThrow<DBOperationResultType>("ResultType", DBOperationResultType.Result)
-            };
+                        : os.GetOrThrow<DBOperationResultType>("ResultType", DBOperationResultType.Result),
+                };
             }
             if (obj is string s)
-                return new DBOperationSetting(s, DBObjectType.StoredProcedure, methodName: null, executeParameters: null, ignoreParameters: null);
+                return new DBOperationSetting(s, DBObjectType.StoredProcedure, methodName: null, executeParameters: null, ignoreParameters: null, specificDBNaming: null);
             throw new NotSupportedException($"{obj} is not a proc");
+        }
+
+        /// <summary>
+        /// Checks if the specific Naming is available. If not available it returns null.
+        /// The schema name and the object name must be at least the length of 1
+        /// </summary>
+        /// <returns>SpecificDBnaming Object if the schema and object name is available</returns>
+        private static SpecificDBNaming? GetSpecificDBObjectNaming(IReadOnlyDictionary<string, object> os)
+        {
+            if (os == null) return null;
+
+            if (os.ContainsKey("SpecificDBNaming"))
+            {
+                if (os["SpecificDBNaming"] is IReadOnlyDictionary<object, object> od)
+                {
+                    var specificDBObjectDict = od.ToDictionary(k => k.Key.ToString()!, k => k.Value) ?? throw new ArgumentNullException("Error on extracting the information from object 'SpecificDBNaming'");
+                    string? dbSchemaName = specificDBObjectDict.GetOrThrow<string?>("DBSchemaName", null);
+                    string? dbObjectName = specificDBObjectDict.GetOrThrow<string?>("DBObjectName", null);
+                    return SpecificDBNaming.CreateSpecifcDBNaming(dbSchemaName, dbObjectName);
+                }
+            }
+            return null;
         }
     }
 }

--- a/DbAccessCodeGen.Library/Objects/DbOperationMetadata.cs
+++ b/DbAccessCodeGen.Library/Objects/DbOperationMetadata.cs
@@ -47,8 +47,8 @@ namespace DbAccessCodeGen.Objects
                     "CommandType.StoredProcedure":
                     "CommandType.Text";
             this.CommandText = dBObjectType == DBObjectType.StoredProcedure ?
-                    name.ToString(false, true) : "SELECT * FROM " + name.ToString(false, true);
-            this.SqlName = name;
+                    AddSquareBracket(name) : "SELECT * FROM " + name.ToString(false, true);
+            this.SqlName = dBObjectType== DBObjectType.StoredProcedure ? AddSquareBracket(name): name ;
             this.Parameters = parameters;
             this.ReplaceParameters = replaceParameters;
             FieldSource = fieldSource;
@@ -62,6 +62,12 @@ namespace DbAccessCodeGen.Objects
             this.ResultType = fields.Count(f => f.Name != null) == 0 ? new Identifier("", "Dictionary<string, object?>") : resultType;
             this.ParameterTypeName = parameters.Count == 0 ? null : parameterTypeName;
             this.Settings = setting;
+        }
+
+
+        private static string AddSquareBracket(DBObjectName name)
+        {
+            return "["+name.Schema+"].["+name.Name+"]";
         }
     }
 

--- a/DbAccessCodeGen/Properties/launchSettings.json
+++ b/DbAccessCodeGen/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Test": {
       "commandName": "Project",
       "commandLineArgs": "-c DbCodeGenConfig.yml",
-      "workingDirectory": "C:\\Projects\\Github\\DbAccessCodeGen\\DbCode.Test"
+      "workingDirectory": "D:\\Projects\\Kull\\GitHub\\DbAccessCodeGen\\DbCode.Test"
     },
     "VP": {
       "commandName": "Project",

--- a/DbCode.Test/DbCodeGenConfig.yml
+++ b/DbCode.Test/DbCodeGenConfig.yml
@@ -9,7 +9,7 @@ ConnectionString: "Server=127.0.0.1;user id=sa;password=abcDEF123#;Initial Catal
 ReplaceParameters:
    DateOfTool: DateTime.Now
 Items:
- - SP: dbo.spGetPets
+ - SP: "[dbo].[spGetPets]"
    IgnoreParameters: 
      - ParameterNoOneLikes
    IgnoreFields:
@@ -41,3 +41,9 @@ Items:
    ResultType: Dictionary
  - SP: spReturnAsReader
    ResultType: Reader
+ - SP:
+   ResultType: Result
+   SpecificDBNaming: 
+    DBSchemaName: Sales.DataDelivery
+    DBObjectName: spReturnDataDelivery
+   

--- a/DbCode.Test/Program.cs
+++ b/DbCode.Test/Program.cs
@@ -68,6 +68,13 @@ namespace DbCode.Test
                 Console.Error.WriteLine("FAILED TEST for spReturnAsReader");
                 Environment.ExitCode = -2;
             }
+            //Testing with specific naming of sp
+            //string testSpecificNaming = (string)dba.spReturnDataDelivery().ToArray().Single()["Test"];
+            //if (test != "hallo")
+            //{
+            //    Console.Error.WriteLine("FAILED TEST for spReturnAsDict");
+            //    Environment.ExitCode = -2;
+            //}
         }
     }
 }

--- a/DbCode.Test/Program.cs
+++ b/DbCode.Test/Program.cs
@@ -2,6 +2,7 @@
 using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 
 namespace DbCode.Test
 {
@@ -68,13 +69,15 @@ namespace DbCode.Test
                 Console.Error.WriteLine("FAILED TEST for spReturnAsReader");
                 Environment.ExitCode = -2;
             }
+
             //Testing with specific naming of sp
-            //string testSpecificNaming = (string)dba.spReturnDataDelivery().ToArray().Single()["Test"];
-            //if (test != "hallo")
-            //{
-            //    Console.Error.WriteLine("FAILED TEST for spReturnAsDict");
-            //    Environment.ExitCode = -2;
-            //}
+            var rdr2 = dba.spReturnDataDelivery().ToArray();
+            if (rdr2.Length != 1)
+            {
+                Console.Error.WriteLine("FAILED TEST for Sales.DataDelivery.spReturnDataDelivery");
+                Console.Error.WriteLine($"Count of entries {rdr2.Length}");
+                Environment.ExitCode = -2;
+            }
         }
     }
 }

--- a/DbCode.Test/ResultSets/Sales.DataDelivery.spReturnDataDelivery.json
+++ b/DbCode.Test/ResultSets/Sales.DataDelivery.spReturnDataDelivery.json
@@ -1,0 +1,26 @@
+[
+  {
+    "Name": "PetId",
+    "TypeName": "int",
+    "IsNullable": false,
+    "MaxLength": null
+  },
+  {
+    "Name": "PetName",
+    "TypeName": "varchar",
+    "IsNullable": false,
+    "MaxLength": 100
+  },
+  {
+    "Name": "IsNice",
+    "TypeName": "bit",
+    "IsNullable": true,
+    "MaxLength": null
+  },
+  {
+    "Name": "ts",
+    "TypeName": "timestamp",
+    "IsNullable": false,
+    "MaxLength": 8
+  }
+]

--- a/DbCode.Test/SetupDB.sh
+++ b/DbCode.Test/SetupDB.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+docker-compose up -d > /dev/null
+
+sleep 20
+
+server="127.0.0.1"
+user="sa"
+pw="abcDEF123#"
+db="CodeGenTestDb"
+shouldVNr=14
+createNewDb=false
+
+hasDb=$(sqlcmd -S "$server" -d master -U "$user" -P "$pw" -Q "SELECT name FROM sys.databases" -h -1 -W | grep -Fx "$db")
+
+echo "has database: $hasDb"
+
+if [ -n "$hasDb" ]; then
+    echo "Db exists"
+    outputVersion=$(sqlcmd -S "$server" -U "$user" -P "$pw" -d "$db" -Q "SELECT * FROM TestDbVersion" -h -1 -W 2>&1)
+
+    if echo "$outputVersion" | grep -iq "invalid object name"; then
+        echo "Will drop and recreate db"
+        createNewDb=true
+    else
+        currentVNr=$(echo "$outputVersion" | sed -n '2p' | xargs)
+        if [ "$currentVNr" != "$shouldVNr" ]; then
+            echo "Will drop and recreate db. Old VNr: $currentVNr, new Nr: $shouldVNr"
+            createNewDb=true
+        fi
+    fi
+else
+    createNewDb=true
+fi
+
+if [ "$createNewDb" = true ]; then
+    echo "Recreate DB..."
+    sqlcmd -S "$server" -U "$user" -P "$pw" -d master -Q "DROP DATABASE IF EXISTS [$db]"
+    sqlcmd -S "$server" -U "$user" -P "$pw" -d master -Q "CREATE DATABASE [$db]"
+    sqlcmd -i "$(dirname "$0")/sqlscript.sql" -S "$server" -U "$user" -P "$pw" -d "$db" -v DbVersion=1
+fi
+
+# docker-compose down

--- a/DbCode.Test/sqlscript.sql
+++ b/DbCode.Test/sqlscript.sql
@@ -189,3 +189,21 @@ BEGIN
 	SELECT 'hallo' AS Test
 END
 GO
+
+-- Testing with specific schema naming
+-- explicit with "." in the name
+
+CREATE SCHEMA [Sales.DataDelivery]
+GO
+
+CREATE PROCEDURE [Sales.DataDelivery].spReturnDataDelivery
+AS
+BEGIN
+		SELECT PetId, PetName, IsNice, ts
+		--geography::STGeomFromText('POINT(0 0)',4326) AS PetPosition Not Supported on .Net Core
+		-- see https://github.com/dotnet/SqlClient/issues/30
+	FROM dbo.Pets
+		WHERE IsNice=1 OR @OnlyNice=0
+		ORDER BY PetId;
+END
+GO

--- a/DbCode.Test/sqlscript.sql
+++ b/DbCode.Test/sqlscript.sql
@@ -203,7 +203,7 @@ BEGIN
 		--geography::STGeomFromText('POINT(0 0)',4326) AS PetPosition Not Supported on .Net Core
 		-- see https://github.com/dotnet/SqlClient/issues/30
 	FROM dbo.Pets
-		WHERE IsNice=1 OR @OnlyNice=0
+		WHERE IsNice=1
 		ORDER BY PetId;
 END
 GO

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="Jint" Version="3.0.0-beta-2037" />
     <PackageVersion Include="Kull.Data" Version="8.0.1" />
-    <PackageVersion Include="Kull.DatabaseMetadata" Version="1.7.0" />
+    <PackageVersion Include="Kull.DatabaseMetadata" Version="1.8.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.2-mauipre.1.22102.15" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-3.final" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="4.1.0" />


### PR DESCRIPTION
This pull request upgrades the project to .NET 8 and updates several package dependencies, including `Kull.DatabaseMetadata` to version 1.8.0. It introduces support for handling special database object naming, including schemas with dots, by escaping object names using square brackets. A new SpecificDBNaming class was added for this purpose. Additionally, a test case was implemented to validate stored procedures with custom schema names. The workflow has been updated accordingly.